### PR TITLE
Update WriteSerializableTask.java

### DIFF
--- a/src/main/java/com/carrotcreative/cream/tasks/WriteSerializableTask.java
+++ b/src/main/java/com/carrotcreative/cream/tasks/WriteSerializableTask.java
@@ -33,6 +33,7 @@ public class WriteSerializableTask extends AsyncTask<Void, Void, Void> {
             oos.writeObject(mObject);
         } catch (Exception e) {
             keep = false;
+            exception = e;
         } finally {
             try {
                 if (oos != null)   oos.close();


### PR DESCRIPTION
Setting variable exception = e in the catch block so that it can be returned in the callback.failure interface.
