### PR TITLE
Make em' safer

### DIFF
--- a/src/main/java/com/carrotcreative/cream/loaders/multiple/MultipleLoader.java
+++ b/src/main/java/com/carrotcreative/cream/loaders/multiple/MultipleLoader.java
@@ -10,11 +10,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class MultipleLoader<Identifier> {
 
     /** This policy requires everything to be downloaded, or else it fails */
-    public static final int STRICT_POLICY = 1;
+    private static final int STRICT_POLICY = 1;
 
     /** This policy tries to download everything,
         but is still successful even if only one element is downloaded */
-    public static final int RELAXED_POLICY = 2;
+    private static final int RELAXED_POLICY = 2;
 
     //===================================
 

--- a/src/main/java/com/carrotcreative/cream/loaders/multiple/MultipleLoaderTuple.java
+++ b/src/main/java/com/carrotcreative/cream/loaders/multiple/MultipleLoaderTuple.java
@@ -4,13 +4,12 @@ import java.io.Serializable;
 
 public class MultipleLoaderTuple {
 
-    public Serializable mContent;
-    public boolean mFromCache;
+    private final Serializable mContent;
+    private final boolean mFromCache;
 
     public MultipleLoaderTuple(Serializable content, boolean fromCache)
     {
         mContent = content;
         mFromCache = fromCache;
     }
-
 }

--- a/src/main/java/com/carrotcreative/cream/loaders/retry/RetryLoader.java
+++ b/src/main/java/com/carrotcreative/cream/loaders/retry/RetryLoader.java
@@ -4,14 +4,14 @@ import android.os.Handler;
 
 public abstract class RetryLoader {
 
-    protected static final int START_RETRY_SECONDS = 2;
-    protected static final int MAX_RETRY_SECONDS = 64;
-    protected static final float RETRY_SECONDS_GROWTH_RATE = 1.5f;
+    private static final int START_RETRY_SECONDS = 2;
+    private static final int MAX_RETRY_SECONDS = 64;
+    private static final float RETRY_SECONDS_GROWTH_RATE = 1.5f;
 
     protected int mAttemptNumber = 0;
-    protected int mRetrySeconds;
+    private int mRetrySeconds;
 
-    public RetryLoader()
+    protected RetryLoader()
     {
         mRetrySeconds = START_RETRY_SECONDS;
     }

--- a/src/main/java/com/carrotcreative/cream/loaders/single/SingleLoader.java
+++ b/src/main/java/com/carrotcreative/cream/loaders/single/SingleLoader.java
@@ -12,8 +12,8 @@ import java.io.Serializable;
 
 public abstract class SingleLoader<T> {
 
-    protected Context mContext;
-    protected CacheStrategy<T> mCacheStrategy;
+    private final Context mContext;
+    private final CacheStrategy<T> mCacheStrategy;
 
     public SingleLoader(Context context, CacheStrategy<T> cacheStrategy)
     {
@@ -25,7 +25,7 @@ public abstract class SingleLoader<T> {
         handleInitialLoad(identifier, callback);
     }
 
-    protected void handleInitialLoad(final T identifier, final SingleLoaderCallback callback)
+    void handleInitialLoad(final T identifier, final SingleLoaderCallback callback)
     {
         mCacheStrategy.handleInitialLoad(identifier, shouldCache(identifier), new CacheStrategyCallback() {
             @Override
@@ -46,7 +46,7 @@ public abstract class SingleLoader<T> {
         });
     }
 
-    protected void handleCacheFailure(final T identifier, final boolean hasExpirationRegard, final SingleLoaderCallback singleLoaderCallback, Exception error)
+    void handleCacheFailure(final T identifier, final boolean hasExpirationRegard, final SingleLoaderCallback singleLoaderCallback, Exception error)
     {
         mCacheStrategy.handleCacheFailure(identifier, hasExpirationRegard, error, new CacheStrategyCallback() {
             @Override
@@ -118,7 +118,7 @@ public abstract class SingleLoader<T> {
      * This can be overwritten in a subclass if you feel
      * 3 isn't the right number
      */
-    protected int mWriteAttempts = 3;
+    private int mWriteAttempts = 3;
 
     /**
      * Just writing content to cache, it shouldn't really ever fail


### PR DESCRIPTION
Many variables, in the loaders folder, were public/protected when private/protected could have been a better option. Made these private.
