### PR TITLE
Add dynamic cast to objects in onSuccess callback

### DIFF
--- a/src/main/java/com/carrotcreative/cream/loaders/multiple/MultipleLoader.java
+++ b/src/main/java/com/carrotcreative/cream/loaders/multiple/MultipleLoader.java
@@ -8,7 +8,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class MultipleLoader<Params extends LoaderParams> {
+public class MultipleLoader<Params extends LoaderParams, Content extends Serializable> {
 
     /** This policy requires everything to be downloaded, or else it fails */
     public static final int STRICT_POLICY = 1;
@@ -19,7 +19,7 @@ public class MultipleLoader<Params extends LoaderParams> {
 
     //===================================
 
-    private ArrayList<MultipleLoaderTuple> mLoaderTuples;
+    private ArrayList<MultipleLoaderTuple<Content>> mLoaderTuples;
     private AtomicInteger mFinishedCounter;
     private final int mDownloadPolicy;
     private int mTotalToLoad;
@@ -29,19 +29,19 @@ public class MultipleLoader<Params extends LoaderParams> {
         mDownloadPolicy = downloadPolicy;
     }
 
-    public void load(final ArrayList<Params> paramsList, SingleLoader<Params> loader, final MultipleLoaderCallback multipleCallback) {
-        mLoaderTuples = new ArrayList<MultipleLoaderTuple>();
+    public void load(final ArrayList<Params> paramsList, SingleLoader<Params, Content> loader, final MultipleLoaderCallback<Content> multipleCallback) {
+        mLoaderTuples = new ArrayList<MultipleLoaderTuple<Content>>();
         mFinishedCounter = new AtomicInteger(0);
         mTotalToLoad = paramsList.size();
 
         for (final Params param : paramsList) {
-            loader.loadSelf(param, new SingleLoaderCallback() {
+            loader.loadSelf(param, new SingleLoaderCallback<Content>() {
 
                 @Override
-                public void success(Serializable content, boolean fromCache) {
+                public void success(Content content, boolean fromCache) {
                     //Adding to our loaderTuples
-                    MultipleLoaderTuple tuple = new MultipleLoaderTuple(content, fromCache);
-                    mLoaderTuples.add(tuple);
+                    MultipleLoaderTuple<Content> loaderTuple = new MultipleLoaderTuple<Content>(content, fromCache);
+                    mLoaderTuples.add(loaderTuple);
                     checkFinished(multipleCallback);
                 }
 

--- a/src/main/java/com/carrotcreative/cream/loaders/multiple/MultipleLoaderCallback.java
+++ b/src/main/java/com/carrotcreative/cream/loaders/multiple/MultipleLoaderCallback.java
@@ -1,9 +1,10 @@
 package com.carrotcreative.cream.loaders.multiple;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 
-public interface MultipleLoaderCallback {
-    void success(ArrayList<MultipleLoaderTuple> content);
+public interface MultipleLoaderCallback<Content extends Serializable> {
+    void success(ArrayList<MultipleLoaderTuple<Content>> content);
     void failure(Exception error);
     void always();
 }

--- a/src/main/java/com/carrotcreative/cream/loaders/multiple/MultipleLoaderTuple.java
+++ b/src/main/java/com/carrotcreative/cream/loaders/multiple/MultipleLoaderTuple.java
@@ -4,13 +4,23 @@ import java.io.Serializable;
 
 public class MultipleLoaderTuple<Content extends Serializable> {
 
-    public Content mContent;
-    public boolean mFromCache;
+    private Content mContent;
+    private boolean mFromCache;
 
     public MultipleLoaderTuple(Content content, boolean fromCache)
     {
         mContent = content;
         mFromCache = fromCache;
+    }
+
+    public Content getContent()
+    {
+        return mContent;
+    }
+
+    public boolean isFromCache()
+    {
+        return mFromCache;
     }
 
 }

--- a/src/main/java/com/carrotcreative/cream/loaders/multiple/MultipleLoaderTuple.java
+++ b/src/main/java/com/carrotcreative/cream/loaders/multiple/MultipleLoaderTuple.java
@@ -2,12 +2,12 @@ package com.carrotcreative.cream.loaders.multiple;
 
 import java.io.Serializable;
 
-public class MultipleLoaderTuple {
+public class MultipleLoaderTuple<Content extends Serializable> {
 
-    public Serializable mContent;
+    public Content mContent;
     public boolean mFromCache;
 
-    public MultipleLoaderTuple(Serializable content, boolean fromCache)
+    public MultipleLoaderTuple(Content content, boolean fromCache)
     {
         mContent = content;
         mFromCache = fromCache;

--- a/src/main/java/com/carrotcreative/cream/loaders/retry/multiple/RetryMultipleLoader.java
+++ b/src/main/java/com/carrotcreative/cream/loaders/retry/multiple/RetryMultipleLoader.java
@@ -1,22 +1,23 @@
 package com.carrotcreative.cream.loaders.retry.multiple;
 
 import com.carrotcreative.cream.loaders.multiple.MultipleLoaderCallback;
-import com.carrotcreative.cream.loaders.multiple.MultipleLoaderTuple;
 import com.carrotcreative.cream.loaders.multiple.MultipleLoader;
+import com.carrotcreative.cream.loaders.multiple.MultipleLoaderTuple;
 import com.carrotcreative.cream.loaders.retry.RetryLoader;
 import com.carrotcreative.cream.params.LoaderParams;
 import com.carrotcreative.cream.loaders.single.SingleLoader;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 
-public class RetryMultipleLoader<Params extends LoaderParams> extends RetryLoader implements MultipleLoaderCallback {
+public class RetryMultipleLoader<Params extends LoaderParams, Content extends Serializable> extends RetryLoader implements MultipleLoaderCallback<Content> {
 
     private RetryMultipleLoaderCallback mRetryMultipleLoaderCallback;
-    private final MultipleLoader<Params> mMultiLoader;
-    private final SingleLoader<Params> mSingleLoader;
+    private final MultipleLoader<Params, Content> mMultiLoader;
+    private final SingleLoader<Params, Content> mSingleLoader;
     private ArrayList<Params> mParamsList;
 
-    public RetryMultipleLoader(MultipleLoader<Params> multiLoader, SingleLoader<Params> singleLoader)
+    public RetryMultipleLoader(MultipleLoader<Params, Content> multiLoader, SingleLoader<Params, Content> singleLoader)
     {
         super();
         mMultiLoader = multiLoader;
@@ -31,7 +32,7 @@ public class RetryMultipleLoader<Params extends LoaderParams> extends RetryLoade
     }
 
     @Override
-    public void success(ArrayList<MultipleLoaderTuple> content) {
+    public void success(ArrayList<MultipleLoaderTuple<Content>> content) {
         mRetryMultipleLoaderCallback.success(content);
     }
 

--- a/src/main/java/com/carrotcreative/cream/loaders/retry/multiple/RetryMultipleLoaderCallback.java
+++ b/src/main/java/com/carrotcreative/cream/loaders/retry/multiple/RetryMultipleLoaderCallback.java
@@ -1,10 +1,12 @@
 package com.carrotcreative.cream.loaders.retry.multiple;
 
+import com.carrotcreative.cream.loaders.multiple.MultipleLoaderTuple;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 
 public interface RetryMultipleLoaderCallback<Content extends Serializable> {
-    void success(ArrayList<Content> content);
+    void success(ArrayList<MultipleLoaderTuple<Content>> content);
     void failedAttempt(int attemptNumber);
     void always();
 }

--- a/src/main/java/com/carrotcreative/cream/loaders/retry/multiple/RetryMultipleLoaderCallback.java
+++ b/src/main/java/com/carrotcreative/cream/loaders/retry/multiple/RetryMultipleLoaderCallback.java
@@ -1,11 +1,10 @@
 package com.carrotcreative.cream.loaders.retry.multiple;
 
-import com.carrotcreative.cream.loaders.multiple.MultipleLoaderTuple;
-
+import java.io.Serializable;
 import java.util.ArrayList;
 
-public interface RetryMultipleLoaderCallback {
-    void success(ArrayList<MultipleLoaderTuple> content);
+public interface RetryMultipleLoaderCallback<Content extends Serializable> {
+    void success(ArrayList<Content> content);
     void failedAttempt(int attemptNumber);
     void always();
 }

--- a/src/main/java/com/carrotcreative/cream/loaders/retry/single/RetrySingleLoader.java
+++ b/src/main/java/com/carrotcreative/cream/loaders/retry/single/RetrySingleLoader.java
@@ -7,13 +7,13 @@ import com.carrotcreative.cream.loaders.single.SingleLoaderCallback;
 
 import java.io.Serializable;
 
-public class RetrySingleLoader<Params extends LoaderParams> extends RetryLoader implements SingleLoaderCallback {
+public class RetrySingleLoader<Params extends LoaderParams, Content extends Serializable> extends RetryLoader implements SingleLoaderCallback<Content> {
 
     private RetrySingleLoaderCallback mRetrySingleLoaderCallback;
-    private final SingleLoader<Params> mLoader;
+    private final SingleLoader<Params, Content> mLoader;
     private Params mParams;
 
-    public RetrySingleLoader(SingleLoader<Params> loader)
+    public RetrySingleLoader(SingleLoader<Params, Content> loader)
     {
         super();
         mLoader = loader;
@@ -32,7 +32,7 @@ public class RetrySingleLoader<Params extends LoaderParams> extends RetryLoader 
     }
 
     @Override
-    public void success(Serializable content, boolean fromCache) {
+    public void success(Content content, boolean fromCache) {
         mRetrySingleLoaderCallback.success(content, fromCache);
     }
 

--- a/src/main/java/com/carrotcreative/cream/loaders/retry/single/RetrySingleLoaderCallback.java
+++ b/src/main/java/com/carrotcreative/cream/loaders/retry/single/RetrySingleLoaderCallback.java
@@ -2,8 +2,8 @@ package com.carrotcreative.cream.loaders.retry.single;
 
 import java.io.Serializable;
 
-public interface RetrySingleLoaderCallback {
-    void success(Serializable content, boolean fromCache);
+public interface RetrySingleLoaderCallback<Content extends Serializable> {
+    void success(Content content, boolean fromCache);
     void failedAttempt(int attemptNumber);
     void always();
 }

--- a/src/main/java/com/carrotcreative/cream/loaders/single/SingleLoader.java
+++ b/src/main/java/com/carrotcreative/cream/loaders/single/SingleLoader.java
@@ -12,12 +12,12 @@ import com.carrotcreative.cream.util.HashingUtil;
 
 import java.io.Serializable;
 
-public abstract class SingleLoader<Params extends LoaderParams> {
+public abstract class SingleLoader<Params extends LoaderParams, Content extends Serializable> {
 
     protected Context mContext;
-    protected CacheStrategy<Params> mCacheStrategy;
+    protected CacheStrategy<Params, Content> mCacheStrategy;
 
-    public SingleLoader(Context context, CacheStrategy<Params> cacheStrategy)
+    public SingleLoader(Context context, CacheStrategy<Params, Content> cacheStrategy)
     {
         mContext = context;
         mCacheStrategy = cacheStrategy;
@@ -48,7 +48,7 @@ public abstract class SingleLoader<Params extends LoaderParams> {
         });
     }
 
-    protected void handleCacheFailure(final Params identifier, final boolean hasExpirationRegard, final SingleLoaderCallback singleLoaderCallback, Exception error)
+    protected void handleCacheFailure(final Params identifier, final boolean hasExpirationRegard, final SingleLoaderCallback<Content> singleLoaderCallback, Exception error)
     {
         mCacheStrategy.handleCacheFailure(identifier, hasExpirationRegard, error, new CacheStrategyCallback() {
             @Override

--- a/src/main/java/com/carrotcreative/cream/loaders/single/SingleLoaderCallback.java
+++ b/src/main/java/com/carrotcreative/cream/loaders/single/SingleLoaderCallback.java
@@ -2,8 +2,8 @@ package com.carrotcreative.cream.loaders.single;
 
 import java.io.Serializable;
 
-public interface SingleLoaderCallback {
-    void success(Serializable content, boolean fromCache);
+public interface SingleLoaderCallback<Content extends Serializable> {
+    void success(Content content, boolean fromCache);
     void failure(Exception error);
     void always();
 }

--- a/src/main/java/com/carrotcreative/cream/strategies/CachePreferred.java
+++ b/src/main/java/com/carrotcreative/cream/strategies/CachePreferred.java
@@ -27,14 +27,14 @@ import java.io.Serializable;
  *     else
  *          ->Hit the cache with no regard to expiration
  */
-public class CachePreferred<T extends LoaderParams, C extends Serializable> extends StandardCacheStrategy<T, C> {
+public class CachePreferred<Identifier extends LoaderParams, Content extends Serializable> extends StandardCacheStrategy<Identifier, Content> {
 
     public CachePreferred(Context context) {
         super(context);
     }
 
     @Override
-    public void handleInitialLoad(T identifier, boolean shouldCache, CacheStrategyCallback callback)
+    public void handleInitialLoad(Identifier identifier, boolean shouldCache, CacheStrategyCallback callback)
     {
         if(shouldCache)
         {

--- a/src/main/java/com/carrotcreative/cream/strategies/CachePreferred.java
+++ b/src/main/java/com/carrotcreative/cream/strategies/CachePreferred.java
@@ -6,6 +6,8 @@ import com.carrotcreative.cream.params.LoaderParams;
 import com.carrotcreative.cream.strategies.generic.CacheStrategyCallback;
 import com.carrotcreative.cream.strategies.generic.StandardCacheStrategy;
 
+import java.io.Serializable;
+
 /**
  * ===== Cache Preferred Strategy =====
  *
@@ -25,7 +27,7 @@ import com.carrotcreative.cream.strategies.generic.StandardCacheStrategy;
  *     else
  *          ->Hit the cache with no regard to expiration
  */
-public class CachePreferred<T extends LoaderParams> extends StandardCacheStrategy<T> {
+public class CachePreferred<T extends LoaderParams, C extends Serializable> extends StandardCacheStrategy<T, C> {
 
     public CachePreferred(Context context) {
         super(context);

--- a/src/main/java/com/carrotcreative/cream/strategies/SourcePreferred.java
+++ b/src/main/java/com/carrotcreative/cream/strategies/SourcePreferred.java
@@ -24,14 +24,14 @@ import java.io.Serializable;
  *     else
  *          ->Hit the cache with no regard to expiration
  */
-public class SourcePreferred<T extends LoaderParams, C extends Serializable> extends StandardCacheStrategy<T, C> {
+public class SourcePreferred<Identifier extends LoaderParams, Content extends Serializable> extends StandardCacheStrategy<Identifier, Content> {
 
     public SourcePreferred(Context context) {
         super(context);
     }
 
     @Override
-    public void handleInitialLoad(T identifier, boolean shouldCache, CacheStrategyCallback callback)
+    public void handleInitialLoad(Identifier identifier, boolean shouldCache, CacheStrategyCallback callback)
     {
         callback.handleFromAPI();
     }

--- a/src/main/java/com/carrotcreative/cream/strategies/SourcePreferred.java
+++ b/src/main/java/com/carrotcreative/cream/strategies/SourcePreferred.java
@@ -6,6 +6,8 @@ import com.carrotcreative.cream.params.LoaderParams;
 import com.carrotcreative.cream.strategies.generic.CacheStrategyCallback;
 import com.carrotcreative.cream.strategies.generic.StandardCacheStrategy;
 
+import java.io.Serializable;
+
 /**
  * ===== Source Preferred Strategy =====
  *
@@ -22,7 +24,7 @@ import com.carrotcreative.cream.strategies.generic.StandardCacheStrategy;
  *     else
  *          ->Hit the cache with no regard to expiration
  */
-public class SourcePreferred<T extends LoaderParams> extends StandardCacheStrategy<T> {
+public class SourcePreferred<T extends LoaderParams, C extends Serializable> extends StandardCacheStrategy<T, C> {
 
     public SourcePreferred(Context context) {
         super(context);

--- a/src/main/java/com/carrotcreative/cream/strategies/generic/CacheStrategy.java
+++ b/src/main/java/com/carrotcreative/cream/strategies/generic/CacheStrategy.java
@@ -6,14 +6,14 @@ import com.carrotcreative.cream.loaders.single.SingleLoaderCallback;
 
 import java.io.Serializable;
 
-public interface CacheStrategy<T extends LoaderParams, C extends Serializable> {
+public interface CacheStrategy<Identifier extends LoaderParams, Content extends Serializable> {
 
-    void handleInitialLoad(final T identifier, final boolean shouldCache, final CacheStrategyCallback callback);
+    void handleInitialLoad(final Identifier identifier, final boolean shouldCache, final CacheStrategyCallback callback);
 
-    void handleCacheFailure(final T identifier, final boolean hasExpirationRegard, Exception error, final CacheStrategyCallback callback);
+    void handleCacheFailure(final Identifier identifier, final boolean hasExpirationRegard, Exception error, final CacheStrategyCallback callback);
 
-    void handleSourceSuccess(final T identifier, final C object, SingleLoader<T, C> singleLoader, SingleLoaderCallback<C> singleLoaderCallback);
+    void handleSourceSuccess(final Identifier identifier, final Content object, SingleLoader<Identifier, Content> singleLoader, SingleLoaderCallback<Content> singleLoaderCallback);
 
-    void handleSourceFailure(final T identifier, Exception error, SingleLoader<T, C> singleLoader, SingleLoaderCallback<C> singleLoaderCallback);
+    void handleSourceFailure(final Identifier identifier, Exception error, SingleLoader<Identifier, Content> singleLoader, SingleLoaderCallback<Content> singleLoaderCallback);
 
 }

--- a/src/main/java/com/carrotcreative/cream/strategies/generic/CacheStrategy.java
+++ b/src/main/java/com/carrotcreative/cream/strategies/generic/CacheStrategy.java
@@ -6,14 +6,14 @@ import com.carrotcreative.cream.loaders.single.SingleLoaderCallback;
 
 import java.io.Serializable;
 
-public interface CacheStrategy<T extends LoaderParams> {
+public interface CacheStrategy<T extends LoaderParams, C extends Serializable> {
 
-    public void handleInitialLoad(final T identifier, final boolean shouldCache, final CacheStrategyCallback callback);
+    void handleInitialLoad(final T identifier, final boolean shouldCache, final CacheStrategyCallback callback);
 
-    public void handleCacheFailure(final T identifier, final boolean hasExpirationRegard, Exception error, final CacheStrategyCallback callback);
+    void handleCacheFailure(final T identifier, final boolean hasExpirationRegard, Exception error, final CacheStrategyCallback callback);
 
-    public void handleSourceSuccess(final T identifier, final Serializable object, SingleLoader<T> singleLoader, SingleLoaderCallback singleLoaderCallback);
+    void handleSourceSuccess(final T identifier, final C object, SingleLoader<T, C> singleLoader, SingleLoaderCallback<C> singleLoaderCallback);
 
-    public void handleSourceFailure(final T identifier, Exception error, SingleLoader<T> singleLoader, SingleLoaderCallback singleLoaderCallback);
+    void handleSourceFailure(final T identifier, Exception error, SingleLoader<T, C> singleLoader, SingleLoaderCallback<C> singleLoaderCallback);
 
 }

--- a/src/main/java/com/carrotcreative/cream/strategies/generic/StandardCacheStrategy.java
+++ b/src/main/java/com/carrotcreative/cream/strategies/generic/StandardCacheStrategy.java
@@ -9,7 +9,7 @@ import com.carrotcreative.cream.util.InternetStatus;
 
 import java.io.Serializable;
 
-public abstract class StandardCacheStrategy<T extends LoaderParams, C extends Serializable> implements CacheStrategy<T, C> {
+public abstract class StandardCacheStrategy<Identifier extends LoaderParams, Content extends Serializable> implements CacheStrategy<Identifier, Content> {
 
     private Context mContext;
 
@@ -19,7 +19,7 @@ public abstract class StandardCacheStrategy<T extends LoaderParams, C extends Se
     }
 
     @Override
-    public void handleCacheFailure(T identifier, boolean hasExpirationRegard, Exception error, CacheStrategyCallback callback)
+    public void handleCacheFailure(Identifier identifier, boolean hasExpirationRegard, Exception error, CacheStrategyCallback callback)
     {
         if (hasExpirationRegard)
         {
@@ -35,7 +35,7 @@ public abstract class StandardCacheStrategy<T extends LoaderParams, C extends Se
     }
 
     @Override
-    public void handleSourceSuccess(T identifier, C object, SingleLoader<T, C> singleLoader, SingleLoaderCallback<C> singleLoaderCallback)
+    public void handleSourceSuccess(Identifier identifier, Content object, SingleLoader<Identifier, Content> singleLoader, SingleLoaderCallback<Content> singleLoaderCallback)
     {
         singleLoader.writeContent(identifier, object);
         singleLoaderCallback.success(object, false); // False, not from cache
@@ -43,7 +43,7 @@ public abstract class StandardCacheStrategy<T extends LoaderParams, C extends Se
     }
 
     @Override
-    public void handleSourceFailure(T identifier, Exception error, SingleLoader<T, C> singleLoader, SingleLoaderCallback<C> singleLoaderCallback)
+    public void handleSourceFailure(Identifier identifier, Exception error, SingleLoader<Identifier, Content> singleLoader, SingleLoaderCallback<Content> singleLoaderCallback)
     {
         if(singleLoader.shouldCache(identifier))
             singleLoader.loadFromCache(identifier, false, singleLoaderCallback);

--- a/src/main/java/com/carrotcreative/cream/strategies/generic/StandardCacheStrategy.java
+++ b/src/main/java/com/carrotcreative/cream/strategies/generic/StandardCacheStrategy.java
@@ -9,7 +9,7 @@ import com.carrotcreative.cream.util.InternetStatus;
 
 import java.io.Serializable;
 
-public abstract class StandardCacheStrategy<T extends LoaderParams> implements CacheStrategy<T> {
+public abstract class StandardCacheStrategy<T extends LoaderParams, C extends Serializable> implements CacheStrategy<T, C> {
 
     private Context mContext;
 
@@ -35,7 +35,7 @@ public abstract class StandardCacheStrategy<T extends LoaderParams> implements C
     }
 
     @Override
-    public void handleSourceSuccess(T identifier, Serializable object, SingleLoader<T> singleLoader, SingleLoaderCallback singleLoaderCallback)
+    public void handleSourceSuccess(T identifier, C object, SingleLoader<T, C> singleLoader, SingleLoaderCallback<C> singleLoaderCallback)
     {
         singleLoader.writeContent(identifier, object);
         singleLoaderCallback.success(object, false); // False, not from cache
@@ -43,7 +43,7 @@ public abstract class StandardCacheStrategy<T extends LoaderParams> implements C
     }
 
     @Override
-    public void handleSourceFailure(T identifier, Exception error, SingleLoader<T> singleLoader, SingleLoaderCallback singleLoaderCallback)
+    public void handleSourceFailure(T identifier, Exception error, SingleLoader<T, C> singleLoader, SingleLoaderCallback<C> singleLoaderCallback)
     {
         if(singleLoader.shouldCache(identifier))
             singleLoader.loadFromCache(identifier, false, singleLoaderCallback);


### PR DESCRIPTION
- Add an overhead of creating Loaders with Content Type
- Prevents the need of explicit typecasting on success result
- Prevents Objects that do not implement Serializable from being used as Content type.
